### PR TITLE
[HOPSFS-387] Release HopsFS 3.4.3.1-EE-RC4

### DIFF
--- a/internal/hopsfsmount/Version.go
+++ b/internal/hopsfsmount/Version.go
@@ -5,7 +5,7 @@ package hopsfsmount
 var (
 	// Add Version tag, manually update
 	// Note: redeploy bin to repo.hops.works
-	VERSION = "3.4.3.1-EE-RC3"
+	VERSION = "3.4.3.1-EE-RC4"
 
 	// GITCommit overwritten automatically by the build
 	GITCOMMIT = "HEAD"


### PR DESCRIPTION
Releases HopsFS 3.4.3.1-EE-RC4.
Tracked by HOPSFS-387.
