### PR TITLE
[HOPSFS-390] Release HopsFS 3.2.0.19-EE-RC2

### DIFF
--- a/internal/hopsfsmount/Version.go
+++ b/internal/hopsfsmount/Version.go
@@ -5,7 +5,7 @@ package hopsfsmount
 var (
 	// Add Version tag, manually update
 	// Note: redeploy bin to repo.hops.works
-	VERSION = "3.2.0.19-EE-RC0"
+	VERSION = "3.2.0.19-EE-RC2"
 
 	// GITCommit overwritten automatically by the build
 	GITCOMMIT = "HEAD"


### PR DESCRIPTION
Releases HopsFS 3.2.0.19-EE-RC2.
Tracked by HOPSFS-390.
